### PR TITLE
add mysql dependency and aplication properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,13 @@
 		<artifactId>keycloak-spring-boot-starter</artifactId>
 	</dependency>
 
+	<!-- MySql-->
+	<dependency>
+		 <groupId>mysql</groupId>
+		<artifactId>mysql-connector-java</artifactId> 
+		<scope>runtime</scope>
+	</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,15 @@ keycloak.resource = sites-management-API
 keycloak.credentials.secret = ytbb5vTuOJbWGzDvtq4jrwrnvJQEhjJ5
 keycloak.use-resource-role-mappings = true
 keycloak.bearer-only=true
+
+
+#mysql
+active.db=mysql
+mysql.type=mysql
+mysql.host=<MySQL server address>
+mysql.port=<MySQL server port>
+mysql.schema=<schema>
+mysql.init.user=<pm_all>
+mysql.init.password=<all_password>
+mysql.user=<pm_rw>
+mysql.password=<rw_password>


### PR DESCRIPTION
### Description:

H2 database to MySQL DB

### What changed?

-MySQL java conector dependency
- MySQL properties in aplication.properties

### How was it tested?

Created and read a owner from the localhost using curl

### Documentation
https://github.com/ES-22-23/Documentation