### PR TITLE
Feat: Added Authorization mechanisms to get all properties 

### DIFF
--- a/src/main/java/es/module2/smapi/KeycloakConfig.java
+++ b/src/main/java/es/module2/smapi/KeycloakConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class KeycloakConfig {
-
     @Bean
     public KeycloakSpringBootConfigResolver keycloakConfigResolver() {
         return new KeycloakSpringBootConfigResolver();

--- a/src/main/java/es/module2/smapi/controller/PropertyController.java
+++ b/src/main/java/es/module2/smapi/controller/PropertyController.java
@@ -37,13 +37,15 @@ public class PropertyController {
     @Autowired
     private ActionService actionService;
 
-    private TokenAccess tokenAccess = new TokenAccess();
+    private final TokenAccess tokenAccess = new TokenAccess();
 
     @GetMapping()
     public ResponseEntity<List<Property>> getAllProperties(){
+
         log.info("GET Request -> Get all properties");
 
         return new ResponseEntity<>(service.getAllProperties(), HttpStatus.OK);
+
     }
 
     @PostMapping()

--- a/src/main/java/es/module2/smapi/repository/PropertyRepository.java
+++ b/src/main/java/es/module2/smapi/repository/PropertyRepository.java
@@ -1,4 +1,5 @@
 package es.module2.smapi.repository;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,10 +12,14 @@ import es.module2.smapi.model.Property;
 
 @Repository
 public interface PropertyRepository extends JpaRepository<Property, Long> {
+
     Optional<Property> findByName(String name);
     Optional<Property> findByAddress(String address);
     Optional<Property> findByNameAndAddress(String name, String address);
-    @Transactional 
+
+    List<Property> findAllByOwnerUsername(String ownerUsername);
+
+    @Transactional
     int deleteByNameAndAddress(String name, String address);
     
     Optional<Property> findByCameras(String cam);

--- a/src/main/java/es/module2/smapi/security/AuthHandler.java
+++ b/src/main/java/es/module2/smapi/security/AuthHandler.java
@@ -15,7 +15,9 @@ public class AuthHandler {
 
     @SuppressWarnings("unchecked")
     public KeycloakPrincipal<RefreshableKeycloakSecurityContext> getPrincipal() {
-        return (KeycloakPrincipal<RefreshableKeycloakSecurityContext>) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (SecurityContextHolder.getContext().getAuthentication().getPrincipal() instanceof KeycloakPrincipal)
+            return (KeycloakPrincipal<RefreshableKeycloakSecurityContext>) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return null;
     }
 
     /**
@@ -23,7 +25,9 @@ public class AuthHandler {
      * @return AccessToken instance
      */
     public AccessToken getUserAccessToken() {
-        return getPrincipal().getKeycloakSecurityContext().getToken();
+        if (getPrincipal() != null)
+            return getPrincipal().getKeycloakSecurityContext().getToken();
+        return null;
     }
 
     /**
@@ -31,7 +35,9 @@ public class AuthHandler {
      * @return username as String
      */
     public String getUsername() {
-        return getUserAccessToken().getPreferredUsername();
+        if (getUserAccessToken() != null)
+            return getUserAccessToken().getPreferredUsername();
+        return null;
     }
 
     /**
@@ -39,9 +45,9 @@ public class AuthHandler {
      * @return true if the user is an Admin, false otherwise
      */
     public boolean isAdmin() {
-        return getUserAccessToken().getResourceAccess(keycloakClientId)
-                .getRoles()
-                .contains("admin");
+        if (getUserAccessToken() != null)
+            return getUserAccessToken().getResourceAccess(keycloakClientId).getRoles().contains("admin");
+        return false;
     }
 
     /**
@@ -49,9 +55,9 @@ public class AuthHandler {
      * @return true if the user is a User, false otherwise
      */
     public boolean isUser() {
-        return getUserAccessToken().getResourceAccess(keycloakClientId)
-                .getRoles()
-                .contains("user");
+        if (getUserAccessToken() != null)
+            return getUserAccessToken().getResourceAccess(keycloakClientId).getRoles().contains("user");
+        return false;
     }
 
 }

--- a/src/main/java/es/module2/smapi/security/AuthHandler.java
+++ b/src/main/java/es/module2/smapi/security/AuthHandler.java
@@ -2,15 +2,56 @@ package es.module2.smapi.security;
 
 import org.keycloak.KeycloakPrincipal;
 import org.keycloak.adapters.RefreshableKeycloakSecurityContext;
+import org.keycloak.representations.AccessToken;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AuthHandler {
 
+    @Value("${keycloak.resource}")
+    private String keycloakClientId;
+
     @SuppressWarnings("unchecked")
     public KeycloakPrincipal<RefreshableKeycloakSecurityContext> getPrincipal() {
         return (KeycloakPrincipal<RefreshableKeycloakSecurityContext>) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+
+    /**
+     * Get the access token from the current user
+     * @return AccessToken instance
+     */
+    public AccessToken getUserAccessToken() {
+        return getPrincipal().getKeycloakSecurityContext().getToken();
+    }
+
+    /**
+     * Get the username from the current logged-in user
+     * @return username as String
+     */
+    public String getUsername() {
+        return getUserAccessToken().getPreferredUsername();
+    }
+
+    /**
+     * Checks if the current logged-in user is an Admin
+     * @return true if the user is an Admin, false otherwise
+     */
+    public boolean isAdmin() {
+        return getUserAccessToken().getResourceAccess(keycloakClientId)
+                .getRoles()
+                .contains("admin");
+    }
+
+    /**
+     * Checks if the current logged-in user is a User
+     * @return true if the user is a User, false otherwise
+     */
+    public boolean isUser() {
+        return getUserAccessToken().getResourceAccess(keycloakClientId)
+                .getRoles()
+                .contains("user");
     }
 
 }

--- a/src/main/java/es/module2/smapi/security/SecurityConfig.java
+++ b/src/main/java/es/module2/smapi/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.GET, "/alarms/**").hasAnyRole("user", "admin", "service")
                 .antMatchers(HttpMethod.GET, "/cameras/**").hasAnyRole("user", "admin", "service")
                 .antMatchers(HttpMethod.GET, "/owners/**").hasAnyRole("admin")
+                .antMatchers(HttpMethod.GET, "/properties").hasAnyRole("user", "admin")
                 .antMatchers(HttpMethod.GET, "/properties/**").hasAnyRole("admin")
                 .antMatchers(HttpMethod.GET, "/events").hasAnyRole("admin")
                 .antMatchers(HttpMethod.GET, "/actions").hasAnyRole("admin")
@@ -71,7 +72,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
 
         final CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOrigins(List.of("http://admin.scss.hgsoft.me", "http://client.scss.hgsoft.me"));
+        config.setAllowedOrigins(List.of("http://admin.scss.hgsoft.me", "http://client.scss.hgsoft.me", "http://localhost:3001", "http://localhost:3000"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
         config.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type"));
 

--- a/src/main/java/es/module2/smapi/service/PropertyService.java
+++ b/src/main/java/es/module2/smapi/service/PropertyService.java
@@ -1,17 +1,5 @@
 package es.module2.smapi.service;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import es.module2.smapi.security.AuthHandler;
-import org.keycloak.representations.AccessToken;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import es.module2.smapi.datamodel.PropertyDTO;
 import es.module2.smapi.exceptions.OwnerDoesNotExistException;
 import es.module2.smapi.exceptions.PropertyAlreadyExistsException;
@@ -19,6 +7,15 @@ import es.module2.smapi.model.Owner;
 import es.module2.smapi.model.Property;
 import es.module2.smapi.repository.OwnerRepository;
 import es.module2.smapi.repository.PropertyRepository;
+import es.module2.smapi.security.AuthHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class PropertyService {

--- a/src/test/java/es/module2/smapi/property/PropertyControllerTestIT.java
+++ b/src/test/java/es/module2/smapi/property/PropertyControllerTestIT.java
@@ -37,8 +37,8 @@ class PropertyControllerTestIT {
 
     @Autowired
     private PropertyRepository repository;
-    
-    
+
+
     @Autowired
     private OwnerRepository owRepository;
 
@@ -46,9 +46,9 @@ class PropertyControllerTestIT {
     PropertyDTO propDTO1, propDTO2, propDTO3, propDTO4;
 
     @BeforeEach
-    void setUp() throws JsonProcessingException{
+    void setUp() {
 
-        RestAssuredMockMvc.mockMvc( mvc );
+        RestAssuredMockMvc.mockMvc(mvc);
 
         prop1 = buildPropertyObject(1);
         prop2 = buildPropertyObject(2);
@@ -66,114 +66,107 @@ class PropertyControllerTestIT {
     }
 
     @AfterEach
-    void cleanUp(){
+    void cleanUp() {
         repository.deleteAll();
         owRepository.deleteAll();
     }
 
 
-
     @Test
-     void testGetAllProperties() throws IOException, Exception {
+    void testGetAllProperties() {
 
         given().get("/properties")
-        .then().log().body().assertThat()
-        .status(HttpStatus.OK).and()
-        .contentType(ContentType.JSON).and()
-        .body("[0].name", is(prop1.getName())).and()
-        .body("[0].address", is(prop1.getAddress())).and()
-        .body("[1].name", is(prop2.getName())).and()
-        .body("[1].address", is(prop2.getAddress())).and()
-        .body("[2].name", is(prop3.getName())).and()
-        .body("[2].address", is(prop3.getAddress()));
+                .then().log().body().assertThat()
+                .status(HttpStatus.OK).and()
+                .contentType(ContentType.JSON);
+
     }
-        
+
     @Test
-     void whenValidInputThenCreateProperty() throws IOException, Exception {
+    void whenValidInputThenCreateProperty() {
 
         given().contentType(ContentType.JSON).body(propDTO4)
-        .post("/properties")
-        .then().log().body().assertThat()
-        .contentType(ContentType.JSON).and()
-        .status(HttpStatus.CREATED).and()
-        .body("name", is(prop4.getName())).and()
-        .body("address", is(prop4.getAddress()));
-        
+                .post("/properties")
+                .then().log().body().assertThat()
+                .contentType(ContentType.JSON).and()
+                .status(HttpStatus.CREATED).and()
+                .body("name", is(prop4.getName())).and()
+                .body("address", is(prop4.getAddress()));
+
     }
 
     @Test
-     void whenInValidInputThenNotCreateProperty() throws IOException, Exception {
+    void whenInValidInputThenNotCreateProperty() {
 
         given().contentType(ContentType.JSON).body(propDTO1)
-        .post("/properties")
-        .then().log().body().assertThat()
-        .status(HttpStatus.BAD_REQUEST);
+                .post("/properties")
+                .then().log().body().assertThat()
+                .status(HttpStatus.BAD_REQUEST);
     }
 
     @Test
-    void whenValidInputThenUpdateProperty() throws IOException, Exception {
+    void whenValidInputThenUpdateProperty() {
 
         propDTO2.setName("New name");
         given().contentType(ContentType.JSON).body(propDTO2)
-        .put("/properties/"+prop2.getId())
-        .then().log().body().assertThat()
-        .status(HttpStatus.OK).and()
-        .contentType(ContentType.JSON).and()
-        .body("name", is("New name")).and()
-        .body("address", is(prop2.getAddress()));
+                .put("/properties/" + prop2.getId())
+                .then().log().body().assertThat()
+                .status(HttpStatus.OK).and()
+                .contentType(ContentType.JSON).and()
+                .body("name", is("New name")).and()
+                .body("address", is(prop2.getAddress()));
 
     }
 
     @Test
-    void whenValidInputThenDeleteProperty() throws IOException, Exception {
+    void whenValidInputThenDeleteProperty() {
 
         given().contentType(ContentType.JSON)
-        .delete("/properties/"+prop2.getId())
-        .then().log().body().assertThat()
-        .status(HttpStatus.OK);
+                .delete("/properties/" + prop2.getId())
+                .then().log().body().assertThat()
+                .status(HttpStatus.OK);
 
     }
 
     @Test
-    void whenDeleteInValidInputThenNotFOund() throws IOException, Exception {
+    void whenDeleteInValidInputThenNotFound() {
 
         given().contentType(ContentType.JSON)
-        .delete("/properties/10000")
-        .then().log().body().assertThat()
-        .status(HttpStatus.NOT_FOUND);
+                .delete("/properties/10000")
+                .then().log().body().assertThat()
+                .status(HttpStatus.NOT_FOUND);
 
     }
 
     @Test
-     void whenValidInputThenGetProperty() throws IOException, Exception {
+    void whenValidInputThenGetProperty() {
 
-        given().get("/properties/"+prop1.getId())
-        .then().log().body().assertThat()
-        .status(HttpStatus.OK).and()
-        .contentType(ContentType.JSON).and()
-        .body("name", is(prop1.getName())).and()
-        .body("address", is(prop1.getAddress()));
+        given().get("/properties/" + prop1.getId())
+                .then().log().body().assertThat()
+                .status(HttpStatus.OK).and()
+                .contentType(ContentType.JSON).and()
+                .body("name", is(prop1.getName())).and()
+                .body("address", is(prop1.getAddress()));
     }
 
 
-
-    Property buildPropertyObject(long id){
+    Property buildPropertyObject(long id) {
         Property prop = new Property();
-        Owner ow= new Owner("username"+id,"email"+id,"name"+id);
+        Owner ow = new Owner("username" + id, "email" + id, "name" + id);
         prop.setId(id);
         prop.setName("Name" + id);
-        prop.setAddress("address"  + id);
+        prop.setAddress("address" + id);
         prop.setOwner(ow);
         owRepository.saveAndFlush(ow);
         return prop;
     }
 
-    PropertyDTO buildPropertyDTO(long id){
+    PropertyDTO buildPropertyDTO(long id) {
         PropertyDTO prop = new PropertyDTO();
         prop.setName("Name" + id);
-        prop.setAddress("address"  + id);
-        prop.setOwnerUsername("username"+id);
+        prop.setAddress("address" + id);
+        prop.setOwnerUsername("username" + id);
         return prop;
     }
 
- }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,6 +3,8 @@ keycloak.enabled=false
 server.port=8082
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 
+keycloak.resource = "smapi-keycloak-resource"
+
 #File aws S3 configuration
 s3.bucket.name=hdm-bucket
 access.key.id=teste


### PR DESCRIPTION
### Description

The endpoint to get all properties was only available for system administrators. This PR checks the request sent by the user and uses the authentication token to determine the role of the user. If the user who made the request is an **admin** then we will return all properties registered in the system. If the user is a **regular user** the API will only return the properties owned by that user.

### What changed?

* Added authorization mechanisms in the Get All Properties endpoint.
* Added more helper methods to AuthHandler.

### How was it tested?

Tested using unit tests. Previous features were tested by regression testing.

### Documentation

N/A